### PR TITLE
Add support for generating certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ postgresql_cert_path: "/etc/pki/tls/certs"
 ```
 ### postgresql_certificates
 This is a `list` of `dict` in the same format as used
-  by the `fedora.linux_system_roles.certificate` role.  Specify this variable if
-  you want the certificate role to generate the certificates for the logging system
-  configured by the logging role. With this example, `self-signed` certificate
-  `logging_cert.crt` is generated in `/etc/pki/tls/certs`.
-  Default to `[]`.
+by the `fedora.linux_system_roles.certificate` role.  Specify this variable if
+you want the certificate role to generate the certificates for the PostgreSQL server
+configured by the PostgreSQL role. With this example, `self-signed` certificate
+`postgresql_cert.crt` is generated in `/etc/pki/tls/certs`.
+Default to `[]`.
 ```yaml
 postgresql_certificates:
   - name: postgresql_cert

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Optionaly you can specify path to server cert using `postgresql_cert_path` varia
 ```ymal
 postgresql_cert_path: "/etc/pki/tls/certs"
 ```
+### postgresql_certificates
+This is a `list` of `dict` in the same format as used
+  by the `fedora.linux_system_roles.certificate` role.  Specify this variable if
+  you want the certificate role to generate the certificates for the logging system
+  configured by the logging role. With this example, `self-signed` certificate
+  `logging_cert.crt` is generated in `/etc/pki/tls/certs`.
+  Default to `[]`.
+```yaml
+postgresql_certificates:
+  - name: postgresql_cert
+    dns: ['localhost', 'www.example.com']
+    ca: self-sign
+```
 ### postgresql_input_file
 For running SQL script define path to your SQL file using `postgresql_input_file`:
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,12 +8,10 @@ postgresql_version: "13"
 postgresql_password: null
 postgresql_cert_name: server
 postgresql_server_tuning: true
-postgresql_key_path: /etc/pki/tls/private
-postgresql_cert_path: /etc/pki/tls/certs
 postgresql_ssl_enable: false
 
 # If you want to generate the certificas in the postgresql role
-# specifi the configuration like this example
+# specify the configuration like this example
 # postgresql_certificates:
 #   - name: postgresql_cert
 #     dns: ['localhost', 'www.example.com']

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,5 +18,4 @@ postgresql_ssl_enable: false
 #   - name: postgresql_cert
 #     dns: ['localhost', 'www.example.com']
 #     ca: self-sign
-postgresql_certificate: []
-
+postgresql_certificates: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,12 @@ postgresql_server_tuning: true
 postgresql_key_path: /etc/pki/tls/private
 postgresql_cert_path: /etc/pki/tls/certs
 postgresql_ssl_enable: false
+
+# If you want to generate the certificas in the postgresql role
+# specifi the configuration like this example
+# postgresql_certificates:
+#   - name: postgresql_cert
+#     dns: ['localhost', 'www.example.com']
+#     ca: self-sign
+postgresql_certificate: []
+

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - fedora.linux_system_roles

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -1,0 +1,7 @@
+---
+- name: Generate certificates
+  include_role:
+    name: fedora.linux_system_roles.certificate
+  vars:
+    certificate_requests: "{{ postgresql_certificates }}"
+  when: postgresql_certificates | length > 0

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -1,7 +1,66 @@
 ---
-- name: Generate certificates
-  include_role:
-    name: fedora.linux_system_roles.certificate
-  vars:
-    certificate_requests: "{{ postgresql_certificates }}"
+- name: Generate certificate using PostgreSQL role
   when: postgresql_certificates | length > 0
+  block:
+    - name: Generate certificates
+      include_role:
+        name: fedora.linux_system_roles.certificate
+      vars:
+        certificate_requests: "{{ postgresql_certificates }}"
+
+    - name: Install certificate from the default path
+      file:
+        src: >-
+          /etc/pki/tls/certs/{{ ( postgresql_certificates |
+          first )['name'] }}.crt
+        dest: /var/lib/pgsql/data/server.crt
+        state: link
+        owner: postgres
+      when: ( postgresql_certificates | first )['name'] is not abs
+
+    - name: Install certificate from the default path
+      file:
+        src: >-
+          /etc/pki/tls/private/{{ ( postgresql_certificates |
+          first )['name'] }}.key
+        dest: /var/lib/pgsql/data/server.key
+        state: link
+        owner: postgres
+      when: ( postgresql_certificates | first )['name'] is not abs
+
+    - name: Install certificate from custom path
+      file:
+        src: "{{ ( postgresql_certificates | first )['name'] }}.crt"
+        dest: /var/lib/pgsql/data/server.crt
+        state: link
+        owner: postgres
+      when: ( postgresql_certificates | first )['name'] is abs
+
+    - name: Install certificate from custom path
+      file:
+        src: "{{ ( postgresql_certificates | first )['name'] }}.key"
+        dest: /var/lib/pgsql/data/server.key
+        state: link
+        owner: postgres
+      when: ( postgresql_certificates | first )['name'] is abs
+
+
+- name: Install user provided TLS certificates for postgresql
+  when:
+    - __postgresql_cert.stat.exists
+    - __postgresql_key.stat.exists
+    - postgresql_certificates | length < 1
+  block:
+    - name: Install certificate file
+      file:
+        src: "{{ postgresql_cert_name }}.crt"
+        dest: /var/lib/pgsql/data/server.crt
+        state: link
+        owner: postgres
+
+    - name: Install postgresql server private key
+      file:
+        src: "{{ postgresql_cert_name }}.key"
+        dest: /var/lib/pgsql/data/server.key
+        state: link
+        owner: postgres

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,28 +87,8 @@
   include_tasks: input_sql_file.yml
   when: postgresql_input_file is defined
 
-- name: Generate certificates
+- name: Generate certificates and install cerificates
   include_tasks: certificate.yml
-
-- name: Install TLS certificates for postgresql
-  file:
-    src: "{{ postgresql_cert_path }}/{{ postgresql_cert_name }}.crt"
-    dest: /var/lib/pgsql/data/{{ postgresql_cert_name }}.crt
-    state: link
-    owner: postgres
-  when:
-    - __postgresql_cert.stat.exists
-    - __postgresql_key.stat.exists
-
-- name: Install postgresql server private key
-  file:
-    src: "{{ postgresql_key_path }}/{{ postgresql_cert_name }}.key"
-    dest: /var/lib/pgsql/data/{{ postgresql_cert_name }}.key
-    state: link
-    owner: postgres
-  when:
-    - __postgresql_cert.stat.exists
-    - __postgresql_key.stat.exists
 
 - name: Enable SSL
   replace:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,6 +87,9 @@
   include_tasks: input_sql_file.yml
   when: postgresql_input_file is defined
 
+- name: Generate certificates
+  include_tasks: certificate.yml
+
 - name: Install TLS certificates for postgresql
   file:
     src: "{{ postgresql_cert_path }}/{{ postgresql_cert_name }}.crt"

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -29,10 +29,10 @@
 
 - name: Check TLS crt file
   stat:
-    path: "{{ postgresql_cert_path }}/{{ postgresql_cert_name }}.crt"
+    path: "{{ postgresql_cert_name }}.crt"
   register: __postgresql_cert
 
 - name: Check TLS private key file
   stat:
-    path: "{{ postgresql_key_path }}/{{ postgresql_cert_name }}.key"
+    path: "{{ postgresql_cert_name }}.key"
   register: __postgresql_key

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -78,7 +78,7 @@
 
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
-{% for item in pg_hba_conf %}
+{% for item in postgresql_pg_hba_conf %}
 {{ item.type }} {{ item.database }} {{ item.user }} {{ item.address | default('') }} {{ item.auth_method }} {{ item.options | default('') }}
 {% endfor %}
 


### PR DESCRIPTION
Based on the conversation from the previous [PR](https://github.com/linux-system-roles/postgresql/pull/5#issuecomment-1311112621), I have decided to add support for generating certificates. For the selinux and firewall feature, I will create an issue to hold it in the TODO list.