### PR TITLE
This commit adds generation of internal configuration file 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,17 +105,7 @@
   file:
     path: /etc/postgresql
     state: directory
-    mode: '0755'
-
-- name: Prepare internal file for configuration
-  copy:
-    content: ""
-    dest: "/etc/postgresql/system-roles-internal.conf"
-    force: false
-    mode: 0600
-    owner: postgres
-    group: postgres
-  notify: Restart postgresql
+    mode: 0755
 
 - name: Link generated conf file with server one
   lineinfile:
@@ -124,51 +114,15 @@
     insertafter: "EOF"
   notify: Restart postgresql
 
-- name: Enable ssl in /etc/postgresql/system-roles-internal.conf
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    line: "ssl = on"
-  when: postgresql_ssl_enable
-
-- name: Disable ssl in /etc/postgresql/system-roles-internal.conf
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    state: absent
-    regex: 'ssl'
-  when: not postgresql_ssl_enable
-  notify: Restart postgresql
-
-- name: Set up recommanded shared_buffers size
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    line: 'shared_buffers = {{ (ansible_memory_mb.real.total / 4) |
-      int | abs }}MB'
-  when: postgresql_server_tuning
-  notify: Restart postgresql
-
-- name: Disable recommanded shared_buffers size
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    state: absent
-    regex: 'shared_buffers'
-  when: not postgresql_server_tuning
-  notify: Restart postgresql
-
-- name: Set up recommended cache_size
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    line: 'effective_cache_size = {{ (ansible_memory_mb.real.total / 2) |
-      int | abs }}MB'
-  when: postgresql_server_tuning
-  notify: Restart postgresql
-
-- name: Disable recommended cache_size
-  lineinfile:
-    path: /etc/postgresql/system-roles-internal.conf
-    state: absent
-    regex: 'effective_cache_size'
-  when: not postgresql_server_tuning
-  notify: Restart postgresql
+- name: Generate postgresql system-roles-internal.conf
+  become: true
+  template:
+    backup: true
+    dest: "/etc/postgresql/system-roles-internal.conf"
+    src: postgresql-internal.conf.j2
+    mode: 0600
+    owner: postgres
+    group: postgres
 
 - name: Generate postgresql system-roles.conf
   when: postgresql_server_conf is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,31 +89,6 @@
 - name: Manage certificates
   include_tasks: certificate.yml
 
-- name: Enable SSL
-  replace:
-    path: /var/lib/pgsql/data/postgresql.conf
-    regexp: '#(ssl\s=\s).*$'
-    replace: '\1on'
-  when:
-    - postgresql_ssl_enable
-  notify: Restart postgresql
-
-- name: Set up recommanded shared_buffers size
-  replace:
-    path: "/var/lib/pgsql/data/postgresql.conf"
-    regexp: '(shared_buffers\s=\s)([0-9]+)(\w\w)'
-    replace: '\1 {{ (ansible_memory_mb.real.total / 4) | int | abs }}MB'
-  when: postgresql_server_tuning
-  notify: Restart postgresql
-
-- name: Set up recommended cache_size
-  replace:
-    path: "/var/lib/pgsql/data/postgresql.conf"
-    regexp: '#(effective_cache_size\s=\s)[0-9]+\w\w'
-    replace: '\1 {{ (ansible_memory_mb.real.total / 2) | int | abs }}MB'
-  when: postgresql_server_tuning
-  notify: Restart postgresql
-
 - name: Configure pg_hba.conf
   become: true
   template:
@@ -126,15 +101,78 @@
   when: postgresql_pg_hba_conf is defined
   notify: Restart postgresql
 
+- name: Create postgresql directory in /etc
+  file:
+    path: /etc/postgresql
+    state: directory
+    mode: '0755'
+
+- name: Prepare internal file for configuration
+  copy:
+    content: ""
+    dest: "/etc/postgresql/system-roles-internal.conf"
+    force: false
+    mode: 0600
+    owner: postgres
+    group: postgres
+  notify: Restart postgresql
+
+- name: Link generated conf file with server one
+  lineinfile:
+    path: /var/lib/pgsql/data/postgresql.conf
+    line: "include_if_exists = '/etc/postgresql/system-roles-internal.conf'"
+    insertafter: "EOF"
+  notify: Restart postgresql
+
+- name: Enable ssl in /etc/postgresql/system-roles-internal.conf
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    line: "ssl = on"
+  when: postgresql_ssl_enable
+
+- name: Disable ssl in /etc/postgresql/system-roles-internal.conf
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    state: absent
+    regex: 'ssl'
+  when: not postgresql_ssl_enable
+  notify: Restart postgresql
+
+- name: Set up recommanded shared_buffers size
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    line: 'shared_buffers = {{ (ansible_memory_mb.real.total / 4) |
+      int | abs }}MB'
+  when: postgresql_server_tuning
+  notify: Restart postgresql
+
+- name: Disable recommanded shared_buffers size
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    state: absent
+    regex: 'shared_buffers'
+  when: not postgresql_server_tuning
+  notify: Restart postgresql
+
+- name: Set up recommended cache_size
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    line: 'effective_cache_size = {{ (ansible_memory_mb.real.total / 2) |
+      int | abs }}MB'
+  when: postgresql_server_tuning
+  notify: Restart postgresql
+
+- name: Disable recommended cache_size
+  lineinfile:
+    path: /etc/postgresql/system-roles-internal.conf
+    state: absent
+    regex: 'effective_cache_size'
+  when: not postgresql_server_tuning
+  notify: Restart postgresql
+
 - name: Generate postgresql system-roles.conf
   when: postgresql_server_conf is defined
   block:
-    - name: Create postgresql directory in /etc
-      file:
-        path: /etc/postgresql
-        state: directory
-        mode: '0755'
-
     - name: Generate postgresql system-roles.conf
       become: true
       template:

--- a/templates/postgresql-internal.conf.j2
+++ b/templates/postgresql-internal.conf.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment }}
+
+{% if postgresql_server_tuning %}
+shared_buffers = {{ (ansible_memory_mb.real.total / 4) | int | abs }}MB
+effective_cache_size = {{ (ansible_memory_mb.real.total / 2) | int | abs }}MB
+{% endif %}
+{% if postgresql_ssl_enable %}
+ssl = on
+{% endif %}


### PR DESCRIPTION
This commit adds a generation of the internal configuration file to be ssl_enable and server_tunnig idempotent and behave correctly after state switching within multiple role runs. Currently tunning variable overwrites values in /var/lib/pgsql/data/postgresql.conf and it isn't possible to recover the default setting in the subsequent runs with switched-off tunning.

Now /var/lib/pgsql/data/postgresql.conf is not modified. Instead of modification, there is the internal configuration file for the system role.