### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:postgresql" | comment(prefix="", postfix="") }}
 # system_role:postgresql
 # PostgreSQL Client Authentication Configuration File
 # ===================================================

--- a/templates/postgresql-internal.conf.j2
+++ b/templates/postgresql-internal.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:postgresql" | comment(prefix="", postfix="") }}
 
 {% if postgresql_server_tuning %}
 shared_buffers = {{ (ansible_memory_mb.real.total / 4) | int | abs }}MB

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:postgresql" | comment(prefix="", postfix="") }}
 
 {% for key, value in postgresql_server_conf.items() %}
 {{ key }} = {{ value }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:PostgreSQL
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.