### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ settings are overwritten.
 ```yaml
 postgresql_server_conf:
   ssl: on
-  shared_buffers: 128 MB
+  shared_buffers: 128MB
   huge_pages: try
 ```
 ### postgresql_ssl_enable

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -1,6 +1,5 @@
 {{ ansible_managed | comment }}
 {{ "system_role:postgresql" | comment(prefix="", postfix="") }}
-# system_role:postgresql
 # PostgreSQL Client Authentication Configuration File
 # ===================================================
 #

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+  when: not __file_content is defined
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ (__file_content | d(__content)).content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -1,0 +1,48 @@
+---
+- name: Test PostgreSQL config file logic, handling
+  hosts: all
+  vars:
+    __main_conf_file: /var/lib/pgsql/data/postgresql.conf
+    __generated_conf_files:
+      - /var/lib/pgsql/data/pg_hba.conf
+      - /etc/postgresql/system-roles.conf
+      - /etc/postgresql/system-roles-internal.conf
+  tasks:
+    - name: Run role with given config
+      include_role:
+        name: linux-system-roles.postgresql
+      vars:
+        postgresql_pg_hba_conf:
+          - type: local
+            database: all
+            user: all
+            auth_method: peer
+          - type: host
+            database: all
+            user: all
+            address: '127.0.0.1/32'
+            auth_method: ident
+        postgresql_server_conf:
+          shared_buffers: 128MB
+          huge_pages: try
+
+    - name: Verify existence of config files
+      stat:
+        path: "{{ item }}"
+      register: __stat
+      failed_when: not __stat.stat.exists
+      loop: "{{ __generated_conf_files }}"
+
+    - name: Verify main conf has link to system roles
+      command: >-
+        grep /etc/postgresql/system-roles-internal.conf
+        {{ __main_conf_file }}
+      changed_when: false
+
+    - name: Check headers for ansible_managed, fingerprint
+      include_tasks: tasks/check_header.yml
+      loop: "{{ __generated_conf_files }}"
+      loop_control:
+        loop_var: __file
+      vars:
+        __fingerprint: "system_role:postgresql"


### PR DESCRIPTION
Remove duplicate fingerprint in hba conf

Fix example of `128 MB` - should be `128MB`

Add test to check config files - handling, logic

Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes these parameters.  `fingerprint` is required,
and one of `__file` or `__file_content`:

* `__file` - the full path of the file to check e.g. `/etc/realmd.conf`
* `__file_content` - the output of `slurp` of the file
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
