### PR TITLE
ci: use dump_packages.py callback to get packages used by role

### DIFF
--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -7,7 +7,7 @@ on:  # yamllint disable-line rule:truthy
     - cron: 0 18 * * 6
 env:
   BRANCH_NAME: weekly-ci
-  COMMIT_MESSAGE: This PR is to trigger periodic CI testing
+  COMMIT_MESSAGE: "ci: This PR is to trigger periodic CI testing"
   BODY_MESSAGE: >-
     This PR is for the purpose of triggering periodic CI testing.
     We don't currently have a way to trigger CI without a PR,
@@ -41,6 +41,11 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout ${{ env.BRANCH_NAME }} || git checkout -b ${{ env.BRANCH_NAME }}
           git rebase main
+          if [ ! -d tests/callback_plugins ]; then
+            mkdir -p tests/callback_plugins
+          fi
+          curl -L -s -o tests/callback_plugins/dump_packages.py https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/main/callback_plugins/dump_packages.py
+          git add tests/callback_plugins
           git commit --allow-empty -m "${{ env.COMMIT_MESSAGE }}"
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 


### PR DESCRIPTION
This adds the dump_packages.py callback which will dump the
arguments to the `package` module (except for `state: absent`)
to the integration test run logs.  The output looks like this:
`lsrpackages: pkg-a pkg-b ...`
We will have tooling which will scrape the logs to extract the
packages used at runtime and testing for all of the supported
combinations of distribution and version.

This also ensures the weekly-ci PR git commit message conforms
to commitlint.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
