### PR TITLE
feat: Enable support for Postgresql 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The role also optimizes the database server settings to improve performance.
 
 ## Requirements
 
-The role currently works with the PostgreSQL server 10, 12, 13, and 15.
+The role currently works with the PostgreSQL server 10, 12, 13, 15 and 16.
 
 ### Collection requirements
 
@@ -23,7 +23,7 @@ ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 
 ### postgresql_verison
 
-You can set the version of the PostgreSQL server to 10, 12, 13, or 15.
+You can set the version of the PostgreSQL server to 10, 12, 13, 15 or 16.
 
 ```yaml
 postgresql_version: "13"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Check if requested version is supported in the system (RHEL8)
   fail:
-    msg: RHEL 8 supports only Postgresql 10, 12, 13 and 15
+    msg: RHEL 8 supports only Postgresql 10, 12, 13, 15 and 16
   when:
     - ansible_facts["os_family"] == "RedHat"
     - ansible_facts["distribution_major_version"] == "8"
@@ -18,7 +18,7 @@
 
 - name: Check if requested version is supported in system (RHEL9)
   fail:
-    msg: RHEL 9 supports only Postgresql 13 and 15
+    msg: RHEL 9 supports only Postgresql 13, 15 and 16
   when:
     - ansible_facts["os_family"] == "RedHat"
     - ansible_facts["distribution_major_version"] == "9"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,8 +6,8 @@
 
 # Examples of non-distribution specific (generic) internal variables:
 __postgresql_packages: [postgresql-server]
-__postgresql_versions_el8: ["10", "12", "13", "15"]
-__postgresql_versions_el9: ["13", "15"]
+__postgresql_versions_el8: ["10", "12", "13", "15", "16"]
+__postgresql_versions_el9: ["13", "15", "16"]
 
 __postgresql_data_dir: /var/lib/pgsql/data
 


### PR DESCRIPTION
Enhancement:
enable using PostgreSQL 16 via this role

Reason:
The new PostgreSQL stream will be available in c9s (RHEL9) and c8s (RHEL8)
