### PR TITLE
ci: support ansible-lint and ansible-test 2.16

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/tests/roles/caller/tasks/main.yml
+++ b/tests/roles/caller/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 # tasks file for caller
 
-- include_role:
+- name: Include role
+  include_role:
     name: "{{ roletoinclude }}"
     public: true
 
-- assert:
+- name: Test variable override
+  assert:
     that: not __caller_override

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,5 +1,5 @@
 ---
-- name: Test role variable override
+- name: Test role include variable override
   hosts: all
   gather_facts: true
   tasks:
@@ -38,6 +38,7 @@
         varfiles: "{{ [facts['distribution']] | product(separators) |
           map('join') | product(versions) | map('join') | list +
           [facts['distribution'], facts['os_family']] }}"
+      register: __varfiles_created
 
     - name: Import role
       import_role:
@@ -45,6 +46,15 @@
       vars:
         roletoinclude: linux-system-roles.postgresql
 
-    - name: Clean up
+    - name: Clean up db instance
       include_tasks: tasks/clean_instance.yml
+      tags: tests::cleanup
+
+    - name: Cleanup
+      file:
+        path: "{{ item.dest }}"
+        state: absent
+      loop: "{{ __varfiles_created.results }}"
+      delegate_to: localhost
+      when: inventory_hostname == ansible_play_hosts_all[0]
       tags: tests::cleanup


### PR DESCRIPTION
Fix yamllint issue with markdownlint config

Add cleanup for tests_include_vars_from_parent.yml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
