### PR TITLE
fix: Enable PostgreSQL stream selection for c9s and RHEL9

### DIFF
--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 9 specific values.
+
+__postgresql_packages: >-
+  {{ ['@postgresql:' + postgresql_version +
+       '/server'] if postgresql_version != '13' else
+       ['postgresql-server'] }}

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 9 specific values.
+
+__postgresql_packages: >-
+  {{ ['@postgresql:' + postgresql_version +
+       '/server'] if postgresql_version != '13' else
+       ['postgresql-server'] }}


### PR DESCRIPTION
c9s/RHEL9 provides PostgreSQL 13 as the default system version as a classic RPM package. Alternative versions are provided as modular content. So, it requires a different installation procedure.

Issue Tracker Tickets (Jira or BZ if any): [RHEL-5274](https://issues.redhat.com/browse/RHEL-5274)
