### PR TITLE
test: tests_versions gather_facts; skip version 16 if not supported

### DIFF
--- a/tests/tests_versions.yml
+++ b/tests/tests_versions.yml
@@ -2,6 +2,7 @@
 ---
 - name: Test installing and uninstalling all supported versions
   hosts: all
+  gather_facts: true
   tasks:
     - name: Skip test if distro does not support multiple versions
       meta: end_host
@@ -19,7 +20,7 @@
 
     - name: Install and cleanup the other supported versions
       include_tasks: tasks/install_and_check.yml
-      loop: "{{ __versions }}"
+      loop: "{{ __versions | difference(__unsuppported_versions) }}"
       when: item != __default_version  # we already installed it
       vars:
         __test_check_version: true
@@ -28,4 +29,11 @@
           if ansible_facts['distribution_major_version'] == '8'
           else __postgresql_versions_el9
           if ansible_facts['distribution_major_version'] == '9'
+          else [] }}"
+        __unsuppported_versions: "{{ ['16']
+          if ansible_facts['distribution'] == 'RedHat' and
+          ((ansible_facts['distribution_major_version'] == '8' and
+          ansible_facts['distribution_version'] is version('8.10', '<'))
+          or (ansible_facts['distribution_major_version'] == '9' and
+          ansible_facts['distribution_version'] is version('9.4', '<')))
           else [] }}"


### PR DESCRIPTION
tests_versions.yml requires facts, so `gather_facts: true`

Skip installing version 16 on 9.3 and earlier, and 8.9 and earlier

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
