### PR TITLE
test: stop and disable service on ostree systems

### DIFF
--- a/tests/tasks/clean_instance.yml
+++ b/tests/tasks/clean_instance.yml
@@ -12,6 +12,13 @@
       ['postgresql', 'postgresql-private-libs'] }}"
   when: not __postgresql_is_ostree | d(false)
 
+- name: Stop and disable postgresql service
+  service:
+    name: postgresql
+    state: stopped
+    enabled: false
+  when: __postgresql_is_ostree | d(false)
+
 - name: Remove data directory
   file:
     path: "{{ __postgresql_data_dir }}"


### PR DESCRIPTION
On non-ostree systems, test cleanup will remove the packages, which will stop, disable, and
remove the services.  On ostree systems, just stop and disable.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
