### PR TITLE
fix: add support for EL10

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,0 +1,1 @@
+postgresql-server

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,0 +1,1 @@
+postgresql-server

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,10 @@
 # This file also serves as a documentation for such a variables.
 
 # Examples of role input variables:
-postgresql_version: "13"
+postgresql_version: "{{ '16' if ansible_facts['os_family'] == 'RedHat'
+  and ansible_facts['distribution'] != 'Fedora'
+  and ansible_facts['distribution_major_version'] == '10'
+  else '13' }}"
 postgresql_password: null
 postgresql_cert_name: null
 postgresql_server_tuning: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,5 +14,11 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-  galaxy_tags: [database, postgresql]
+  galaxy_tags:
+    - database
+    - el8
+    - el9
+    - el10
+    - fedora
+    - postgresql
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,16 @@
     - ansible_facts["distribution_major_version"] == "9"
     - postgresql_version | string not in __postgresql_versions_el9
 
+- name: Check if requested version is supported in system (RHEL10)
+  fail:
+    msg: >-
+      RHEL 10 supports only Postgresql versions
+      {{ __postgresql_versions_el10 | join(",") }}
+  when:
+    - ansible_facts["os_family"] == "RedHat"
+    - ansible_facts["distribution_major_version"] == "10"
+    - postgresql_version | string not in __postgresql_versions_el10
+
 - name: Check requested and installed version of Postgresql
   fail:
     msg: >-

--- a/tests/tests_versions.yml
+++ b/tests/tests_versions.yml
@@ -7,7 +7,7 @@
     - name: Skip test if distro does not support multiple versions
       meta: end_host
       when: ansible_facts['distribution'] not in ['CentOS', 'RedHat'] or
-        ansible_facts['distribution_major_version'] not in ["8", "9"]
+        ansible_facts['distribution_major_version'] not in ["8", "9", "10"]
 
     - name: Install and cleanup default version
       include_tasks: tasks/install_and_check.yml
@@ -33,6 +33,8 @@
           if ansible_facts['distribution_major_version'] == '8'
           else __postgresql_versions_el9
           if ansible_facts['distribution_major_version'] == '9'
+          else __postgresql_versions_el10
+          if ansible_facts['distribution_major_version'] == '10'
           else [] }}"
         __unsuppported_versions: "{{ ['16']
           if ansible_facts['distribution'] == 'RedHat' and

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+__postgresql_packages: >-
+  {{ ['@postgresql:' + postgresql_version +
+       '/server'] if postgresql_version != '16' else
+       ['postgresql-server'] }}

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+__postgresql_packages: >-
+  {{ ['@postgresql:' + postgresql_version +
+       '/server'] if postgresql_version != '16' else
+       ['postgresql-server'] }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,6 +8,7 @@
 __postgresql_packages: [postgresql-server]
 __postgresql_versions_el8: ["10", "12", "13", "15", "16"]
 __postgresql_versions_el9: ["13", "15", "16"]
+__postgresql_versions_el10: ["16"]
 
 __postgresql_data_dir: /var/lib/pgsql/data
 


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Added variables for el10.  Looks like the default version on el10
is 16.  No other versions (yet).

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
