### PR TITLE
fix: postgresql_cert_name didn't work properly, using this parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ postgresql_ssl_enable: true
 If you want to use your own certificate and private key, use the
 `postgresql_cert_name` variable to specify the certificate name. You must keep
 both certificate and key files in the same directory and under the same name
-with the `.crt` and `.key` suffixes.
+with the `.crt` and `.key` suffixes on the managed node. The value should be an
+absolute path.
 
 For example, if your certificate file is located in `/etc/certs/server.crt` and
 your private key in `/etc/certs/server.key`, set the `postgresql_cert_name`

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -52,6 +52,9 @@
     - __postgresql_cert.stat.exists
     - __postgresql_key.stat.exists
     - postgresql_certificates | length < 1
+  vars:
+    __pg_server_crt: "{{ __postgresql_data_dir }}/server.crt"
+    __pg_server_key: "{{ __postgresql_data_dir }}/server.key"
   block:
     - name: Install certificate file
       file:

--- a/tests/tests_custom_certificate.yml
+++ b/tests/tests_custom_certificate.yml
@@ -1,0 +1,49 @@
+---
+
+- name: Test PostgreSQL server with ssl support using certificate role
+  hosts: all
+  tasks:
+    - name: Test PostgreSQL server user certificate in custom path
+      vars:
+        postgresql_password: redhat
+      block:
+        - name: Generate certificate using certificate role
+          include_role:
+            name: fedora.linux_system_roles.certificate
+          vars:
+            certificate_requests:
+              - name: /etc/pki/tls/certs/postgresql_test
+                dns: www.example.com
+                ca: self-sign
+
+        - name: Deploy postgresql
+          include_tasks: tasks/install_and_check.yml
+          vars:
+            __test_clean_instance: false
+            __test_check_unix_socket: false
+            postgresql_cert_name: /etc/pki/tls/certs/postgresql_test
+            postgresql_ssl_enable: true
+            postgresql_pg_hba_conf:
+              - type: hostssl
+                database: all
+                user: all
+                auth_method: md5
+                address: '127.0.0.1/32'
+
+        - name: Gather output of psql
+          environment:
+            PGPASSWORD: "{{ postgresql_password }}"
+          shell: |
+            set -euo pipefail
+            echo "\conninfo" | psql -U postgres -h 127.0.0.1
+          register: result
+          changed_when: false
+
+        - name: Check output of psql
+          assert:
+            that: >-
+              "SSL connection" in result.stdout
+      always:
+        - name: Clean up
+          include_tasks: tasks/clean_instance.yml
+          tags: tests::cleanup


### PR DESCRIPTION
postgresql_cert_name parameter caused an error. Because there is a missing variable __pg_server_crt definition in the correct context. This commit also enhances the description of postgresql_cern_name variable.


Issue Tracker Tickets (Jira or BZ if any):  SYSROLES-157
