### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ postgresql_password: !vault |
           ....
 ```
 
+This option is not available for running the role in container builds.
+
 ### postgresql_pg_hba_conf
 
 The content of the `postgresql_pg_hba_conf` variable replaces the default
@@ -128,6 +130,8 @@ To run an SQL script, define a path to your SQL file by using the
 ```yaml
 postgresql_input_file: "/tmp/mypath/file.sql"
 ```
+
+This option is not available for running the role in container builds.
 
 ### postgresql_server_tuning
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: postgresql
     state: restarted
+  when: __postgresql_is_booted | bool

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
         - "8"
         - "9"
   galaxy_tags:
+    - containerbuild
     - database
     - el8
     - el9

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,17 +61,9 @@
 
 - name: Init DB
   when: not __postgresql_conf.stat.exists
-  block:
-    - name: Init DB
-      command:
-        cmd: postgresql-setup --initdb
-        creates: "{{ __postgresql_main_conf_file }}"
-
-    - name: Start Postgresql server
-      service:
-        name: postgresql
-        state: started
-        enabled: true
+  command:
+    cmd: postgresql-setup --initdb
+    creates: "{{ __postgresql_main_conf_file }}"
 
 - name: Enable and start existing instance of postgresql server
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,21 +59,47 @@
       ternary(__postgresql_packages | reject('match', '^@'),
               __postgresql_packages) | list }}"
 
-- name: Init DB
-  when: not __postgresql_conf.stat.exists
+- name: Init DB on booted systems
+  when:
+   - not __postgresql_conf.stat.exists
+   - __postgresql_is_booted | bool
   command:
     cmd: postgresql-setup --initdb
+    creates: "{{ __postgresql_main_conf_file }}"
+
+# this is tricky: postgresql-setup calls `systemctl` to query the unit file and
+# state, but that doesn't work in container build environments; so patch them
+# out and replace with static values
+- name: Init DB on non-booted systems
+  when:
+   - not __postgresql_conf.stat.exists
+   - not __postgresql_is_booted | bool
+  shell:
+    cmd: |
+      set -euo pipefail
+      setup=$(mktemp --suffix=-pgsetup)
+      sed -r 's@systemctl show -p ([[:alnum:]]+) ".*service"@grep ^\1= /usr/lib/systemd/system/postgresql.service@;
+              s/systemctl show -p \$nr_option.*service/echo NeedDaemonReload=no/' \
+          /usr/bin/postgresql-setup > $setup
+      chmod a+rx $setup
+      $setup --initdb
+      rm $setup
     creates: "{{ __postgresql_main_conf_file }}"
 
 - name: Enable and start existing instance of postgresql server
   service:
     name: postgresql
-    state: started
+    state: "{{ 'started' if __postgresql_is_booted else omit }}"
     enabled: true
 
 - name: Set and enable password
   when: postgresql_password is not none
   block:
+    - name: Fail on non-booted hosts
+      fail:
+        msg: "postgresql_password option is only supported on booted hosts, not container builds"
+      when: not  __postgresql_is_booted | bool
+
     - name: Set password for super user
       become: true
       become_user: postgres
@@ -93,6 +119,13 @@
         replace: 'md5'
         backup: true
       notify: Restart postgresql
+
+- name: Fail input_file on non-booted hosts
+  fail:
+    msg: "postgresql_input_file option is only supported on booted hosts, not container builds"
+  when:
+    - not  __postgresql_is_booted | bool
+    - postgresql_input_file is defined
 
 - name: Run provided SQL script
   include_tasks: input_sql_file.yml

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -6,7 +6,7 @@
     difference(ansible_facts.keys() | list) | length > 0
 
 - name: Determine if system is ostree and set flag
-  when: not __postgresql_is_ostree is defined
+  when: __postgresql_is_ostree is not defined
   block:
     - name: Check if system is ostree
       stat:
@@ -16,6 +16,26 @@
     - name: Set flag to indicate system is ostree
       set_fact:
         __postgresql_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
+- name: Determine if system is booted with systemd
+  when: __postgresql_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __postgresql_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
 
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Set platform/version specific variables
       include_role:
-        name: linux-system-roles.template
+        name: linux-system-roles.postgresql
         tasks_from: set_vars.yml
         public: true
 

--- a/tests/tasks/clean_instance.yml
+++ b/tests/tasks/clean_instance.yml
@@ -15,7 +15,7 @@
 - name: Stop and disable postgresql service
   service:
     name: postgresql
-    state: stopped
+    state: "{{ 'stopped' if __postgresql_is_booted else omit }}"
     enabled: false
   when: __postgresql_is_ostree | d(false)
 

--- a/tests/tasks/install_and_check.yml
+++ b/tests/tasks/install_and_check.yml
@@ -14,6 +14,7 @@
       # noqa command-instead-of-module
       command: systemctl is-active postgresql
       changed_when: false
+      when: __postgresql_is_booted | bool
 
     - name: Test - postgresql-server is enabled
       # noqa command-instead-of-module
@@ -28,7 +29,9 @@
         echo '\q' | psql
       async: 3             # in case of password prompt we need to fail
       changed_when: false
-      when: __test_check_unix_socket | d(true)
+      when:
+        - __test_check_unix_socket | d(true)
+        - __postgresql_is_booted | bool
 
     - name: Check - server tuning is used - shared buffers
       become: true
@@ -38,14 +41,18 @@
         echo "SHOW shared_buffers;" | psql
       register: result
       changed_when: false
-      when: __test_check_unix_socket | d(true)
+      when:
+        - __test_check_unix_socket | d(true)
+        - __postgresql_is_booted | bool
 
     - name: Test - server tuning is used - shared buffers
       assert:
         that: >
           (ansible_memory_mb.real.total/4) | int | abs | string
           in result.stdout
-      when: __test_check_unix_socket | d(true)
+      when:
+        - __test_check_unix_socket | d(true)
+        - __postgresql_is_booted | bool
 
     - name: Check - server tuning is used - effective cache size
       become: true
@@ -55,14 +62,18 @@
         echo "SHOW effective_cache_size;" | psql
       register: result
       changed_when: false
-      when: __test_check_unix_socket | d(true)
+      when:
+        - __test_check_unix_socket | d(true)
+        - __postgresql_is_booted | bool
 
     - name: Test - server tuning is used - effective cache size
       assert:
         that: >
           (ansible_memory_mb.real.total/2) | int | abs | string
             in result.stdout
-      when: __test_check_unix_socket | d(true)
+      when:
+        - __test_check_unix_socket | d(true)
+        - __postgresql_is_booted | bool
 
     - name: Check postgresql version matches postgresql_version
       command: postgres --version

--- a/tests/tests_certificate.yml
+++ b/tests/tests_certificate.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test PostgreSQL server with ssl support using certificate role
   hosts: all
+  tags:
+    # certificate role does not work in container builds
+    - tests::booted
   tasks:
     - name: Test PostgreSQL server with certificate in default path
       vars:

--- a/tests/tests_custom_certificate.yml
+++ b/tests/tests_custom_certificate.yml
@@ -2,6 +2,9 @@
 
 - name: Test PostgreSQL server with ssl support using certificate role
   hosts: all
+  tags:
+    # certificate role does not work in container builds
+    - tests::booted
   tasks:
     - name: Test PostgreSQL server user certificate in custom path
       vars:

--- a/tests/tests_input_file.yml
+++ b/tests/tests_input_file.yml
@@ -28,6 +28,18 @@
           assert:
             that: >
               "1 row" in result.stdout
+
+      rescue:
+        - name: Expected to fail in non-booted systems, check error
+          assert:
+            that: '"postgresql_input_file option is only supported on booted hosts" in ansible_failed_result.msg'
+          when: not __postgresql_is_booted | bool
+
+        - name: Role must succeed on booted systems
+          fail:
+            msg: "Unexpected failure on booted system: {{ ansible_failed_result.msg }}"
+          when: __postgresql_is_booted | bool
+
       always:
         - name: Clean up
           include_tasks: tasks/clean_instance.yml


### PR DESCRIPTION
Feature: Support running the mssql role during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: These flags enable running the bootc container scenarios in CI, which ensures that the role works in buildah build environment. This allows us to officially support this role for image mode builds.

Fixes https://issues.redhat.com/browse/RHEL-92934

## Summary by Sourcery

Add support for running the PostgreSQL system role in container build environments, enabling compatibility with image-based and bootc container scenarios.

New Features:
- Enable the role to run in non-booted (container build) environments by detecting systemd availability and adjusting behavior accordingly.

Enhancements:
- Restrict certain options (e.g., postgresql_password, postgresql_input_file) to booted systems and provide clear error messages when used in container builds.
- Update documentation to clarify option availability in container builds.
- Tag tests and adjust test logic to distinguish between booted and container build scenarios.
- Add 'containerbuild' tag to role metadata for discoverability.

Tests:
- Update and extend tests to cover container build scenarios and ensure correct error handling for unsupported options.