### PR TITLE
fix: Fixes for Ansible 2.19

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -25,6 +25,7 @@
       command: systemctl is-system-running
       register: __is_system_running
       changed_when: false
+      check_mode: false
       failed_when: false
 
     - name: Require installed systemd

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
Fixes for the [f42/ansible 2.19 failures](https://github.com/linux-system-roles/postgresql/actions/runs/15539437926/job/43746421145) introduced in #128. This isn't complete yet, so starting with draft.

## Summary by Sourcery

Fix Ansible 2.19 compatibility issues in tests and tasks by updating the managed header variable name and disabling check_mode for the systemctl check

Bug Fixes:
- Update header check test to use __ansible_managed variable name for Ansible 2.19
- Disable check_mode on the systemctl is-system-running task to avoid failures in check mode