### PR TITLE
Really remove sql script from the host

### DIFF
--- a/tasks/input_sql_file.yml
+++ b/tasks/input_sql_file.yml
@@ -42,4 +42,4 @@
 - name: Remove sql script from the host {{ postgresql_input_file }}
   file:
     state: absent
-    path: /tmp/input.sql
+    path: "{{ __postgresql_sql_tempfile.path }}"


### PR DESCRIPTION
Enhancement:

Reason:

SQL was not remove on the remove host, as we were not using the variable but a fixed path.

Result:

Issue Tracker Tickets (Jira or BZ if any):
