### PR TITLE
test: ensure all facts/vars are defined for testing

### DIFF
--- a/tests/tasks/install_and_check.yml
+++ b/tests/tasks/install_and_check.yml
@@ -8,6 +8,13 @@
         public: true
       when: __run_role | d(true) | bool
 
+    - name: Run postgresql role to set vars only
+      include_role:
+        name: linux-system-roles.postgresql
+        public: true
+        tasks_from: set_vars.yml
+      when: not __run_role | d(true) | bool
+
     - name: Flush handlers
       meta: flush_handlers
 


### PR DESCRIPTION
ensure all facts/vars are defined for testing

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Include the postgresql role’s set_vars.yml in install_and_check test to populate all required facts and variables when __run_role is false