### PR TITLE
feat: new variable `postgresql_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ container build is independent of the actual deployment.
 
 See the [`examples/`](examples) for details.
 
+### postgresql_secure_logging
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, private keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `postgresql_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+Default: `true`
+
 ## Idempotence
 
 This section should cover role behavior for repeated runs.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,4 @@ postgresql_ssl_enable: false
 #     dns: ['localhost', 'www.example.com']
 #     ca: self-sign
 postgresql_certificates: []
+postgresql_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - name: Gather the package facts
   package_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Check if requested version is supported in the system (RHEL8)
   fail:
@@ -133,7 +134,7 @@
         cmd: >
           psql -c "ALTER USER postgres WITH ENCRYPTED PASSWORD
           '{{ postgresql_password }}';"
-      no_log: true
+      no_log: "{{ postgresql_secure_logging }}"
       changed_when: false
 
     - name: Enable logging in by password


### PR DESCRIPTION
Feature: Introduce the `postgresql_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, package_facts produces verbose output that clutters logs during normal operation.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ postgresql_secure_logging }}", allowing users to set postgresql_secure_logging: false for debugging while maintaining secure defaults (true)
  - package_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable postgresql_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable secure logging toggle and adjust logging behavior for sensitive tasks and facts gathering.

New Features:
- Add the postgresql_secure_logging variable to control logging of sensitive tasks, defaulting to true.

Enhancements:
- Gate sensitive credential-handling tasks' no_log behavior on postgresql_secure_logging to allow controlled debugging.
- Suppress package_facts output by default and only show it at higher Ansible verbosity levels.
- Document the postgresql_secure_logging variable and its usage in the README.