### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Gather the package facts
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Check if requested version is supported in the system (RHEL8)
   fail:


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Bug Fixes:
- Correct the no_log condition for the package_facts task so its output is only shown when Ansible verbosity is at level 3 or above.